### PR TITLE
feat: 引入强类型配置

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -23,6 +23,26 @@
             "winbw",
             "winxp"
         ],
+        "labels": [
+            "经典复刻",
+            "纯色风格",
+            "Hibbeler 风格",
+            "冰晶风格",
+            "马里奥主题",
+            "Maviz 风格",
+            "地雷主题",
+            "迷幻风格",
+            "海洋风格",
+            "吃豆人主题",
+            "铁血战士主题",
+            "手绘涂鸦风格",
+            "符号风格",
+            "未知风格",
+            "Windows Vista 风格",
+            "Windows 98 风格",
+            "Windows 黑白风格",
+            "Windows XP 风格"
+        ],
         "default": "winxp"
     },
     "difficulty_level": {

--- a/core/config.py
+++ b/core/config.py
@@ -1,0 +1,86 @@
+# config.py
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from pathlib import Path
+from typing import Any, get_type_hints
+
+from astrbot.api import logger
+from astrbot.core.config.astrbot_config import AstrBotConfig
+from astrbot.core.star.context import Context
+from astrbot.core.star.star_tools import StarTools
+from astrbot.core.utils.astrbot_path import get_astrbot_plugin_path
+
+from .model import GameSpec
+
+
+class ConfigNode:
+    """配置节点：dict → 强类型属性访问（极简版）"""
+
+    _SCHEMA_CACHE: dict[type, dict[str, type]] = {}
+
+    @classmethod
+    def _schema(cls) -> dict[str, type]:
+        return cls._SCHEMA_CACHE.setdefault(cls, get_type_hints(cls))
+
+    def __init__(self, data: MutableMapping[str, Any]):
+        object.__setattr__(self, "_data", data)
+        for key in self._schema():
+            if key in data:
+                continue
+            if hasattr(self.__class__, key):
+                continue
+            logger.warning(f"[config:{self.__class__.__name__}] 缺少字段: {key}")
+
+    def __getattr__(self, key: str) -> Any:
+        if key in self._schema():
+            return self._data.get(key)
+        raise AttributeError(key)
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        if key in self._schema():
+            self._data[key] = value
+            return
+        object.__setattr__(self, key, value)
+
+
+# ============ 插件自定义配置 ==================
+
+
+class PluginConfig(ConfigNode):
+    default_skin: str
+    difficulty_level: list[str]
+    ban_time: int
+    use_gui: bool
+
+    _plugin_name = "astrbot_plugin_minesweeper"
+
+    def __init__(self, cfg: AstrBotConfig, context: Context):
+        super().__init__(cfg)
+        self.context = context
+
+        self.data_dir = StarTools.get_data_dir(self._plugin_name)
+        self.plugin_dir = Path(get_astrbot_plugin_path()) / self._plugin_name
+        self.cache_dir = self.data_dir / "cache"
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.skins_dir = self.plugin_dir / "skins"
+        self.font_path = self.plugin_dir / "font.ttf"
+
+        self.level_mapping: dict[str, GameSpec] = self._parse_difficulty_level()
+        self.level_keys = list(self.level_mapping.keys())
+        self.default_preset = self.level_mapping[self.level_keys[0]]
+
+    def _parse_difficulty_level(self) -> dict[str, GameSpec]:
+        result = {}
+        if not self.difficulty_level:
+            self.difficulty_level.append("初级 8 8 10")
+        for item in self.difficulty_level:
+            name, rows, cols, nums = item.split()
+            result[name] = GameSpec(int(rows), int(cols), int(nums))
+        return result
+
+    def is_supported_level(self, name: str) -> bool:
+        return name in self.level_keys
+
+    def get_spec(self, name: str) -> GameSpec:
+        return self.level_mapping.get(name) or self.default_preset

--- a/core/skin.py
+++ b/core/skin.py
@@ -1,11 +1,11 @@
 import random
 from dataclasses import dataclass
-from pathlib import Path
 
 from PIL import Image
 from PIL.Image import Image as IMG
 
 from .model import GameSpec
+from .config import PluginConfig
 
 
 @dataclass
@@ -18,8 +18,9 @@ class Skin:
 
 
 class SkinManager:
-    def __init__(self, skins_dir: Path):
-        self.skins_dir = skins_dir
+    def __init__(self, config: PluginConfig):
+        self.cfg = config
+        self.skins_dir = config.skins_dir
 
         self._skin_names = []
         self._skin_cache: dict[tuple[str, int, int], Skin] = {}

--- a/main.py
+++ b/main.py
@@ -66,7 +66,7 @@ class MinesweeperPlugin(Star):
             yield event.plain_result("你已经在进行扫雷游戏了")
             return
 
-        if self.cfg.is_supported_level(level_name):
+        if not self.cfg.is_supported_level(level_name):
             yield event.plain_result(f"难度仅支持：{self.cfg.level_keys}")
             return
         spec = self.cfg.get_spec(level_name)

--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@ import asyncio
 import re
 import shutil
 import threading
-from pathlib import Path
 
 from astrbot.api import logger
 from astrbot.api.event import filter
@@ -13,12 +12,12 @@ from astrbot.core.platform import AstrMessageEvent
 from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
     AiocqhttpMessageEvent,
 )
-from astrbot.core.star.star_tools import StarTools
 
 from .core.game import GameManager, MineSweeper
-from .core.model import GameSpec, MarkResult, OpenResult
+from .core.model import MarkResult, OpenResult
 from .core.renderer import MineSweeperRenderer
 from .core.skin import SkinManager
+from .core.config import PluginConfig
 from .core.utils import detect_desktop, parse_position, set_group_ban
 from .sender import MessageSender
 
@@ -26,27 +25,12 @@ from .sender import MessageSender
 class MinesweeperPlugin(Star):
     def __init__(self, context: Context, config: AstrBotConfig):
         super().__init__(context)
-        self.config = config
-
-        self.level_preset: dict[str, GameSpec] = self._parse_difficulty_level(config)
-        self.level_keys = list(self.level_preset.keys())
-        if len(self.level_keys) == 0:
-            raise ValueError("没有配置扫雷难度")
-        self.default_preset = self.level_preset[self.level_keys[0]]
-
-        self.data_dir = StarTools.get_data_dir()
-        self.cache_dir = self.data_dir / "cache"
-        self.cache_dir.mkdir(parents=True, exist_ok=True)
-
-        self.skins_dir = Path(__file__).parent / "skins"
-        self.skin_mgr = SkinManager(self.skins_dir)
-
-        self.font_path = Path(__file__).parent / "font.ttf"
-
+        self.cfg = PluginConfig(config, context)
+        self.skin_mgr = SkinManager(self.cfg)
         self.game_mgr = GameManager()
-        self._cleanup_task: asyncio.Task | None = None
         self.sender = MessageSender(config)
 
+        self._cleanup_task: asyncio.Task | None = None
         self.loop: asyncio.AbstractEventLoop | None = None
 
     async def initialize(self):
@@ -57,36 +41,23 @@ class MinesweeperPlugin(Star):
 
     async def terminate(self):
         """插件卸载时"""
-        # 重新创建缓存目录
-        if self.cache_dir.exists():
-            shutil.rmtree(self.cache_dir)
-        self.cache_dir.mkdir(parents=True, exist_ok=True)
-        logger.info("[扫雷] 插件已卸载")
-
-    def _parse_difficulty_level(self, conf: dict) -> dict[str, GameSpec]:
-        result = {}
-
-        for item in conf.get("difficulty_level", []):
-            name, rows, cols, nums = item.split()
-            result[name] = GameSpec(int(rows), int(cols), int(nums))
-
-        return result
+        if self.cfg.cache_dir.exists():
+            shutil.rmtree(self.cfg.cache_dir)
 
     def _save_img_bytes(self, event: AstrMessageEvent, img_bytes: bytes) -> str:
         """把图片 bytes 落盘，返回绝对路径"""
         sid = event.session_id
         uid = event.get_sender_id()
         fname = f"{sid}_{uid}.png"
-        fpath = self.cache_dir / fname
+        fpath = self.cfg.cache_dir / fname
         fpath.write_bytes(img_bytes)
         return str(fpath.absolute())
-
 
     @filter.command("扫雷", alias={"开始扫雷"})
     async def start_minesweeper(
         self,
         event: AstrMessageEvent,
-        level: str = "",
+        level_name: str = "",
         skin_index: int | None = None,
     ):
         sid = event.session_id
@@ -95,22 +66,22 @@ class MinesweeperPlugin(Star):
             yield event.plain_result("你已经在进行扫雷游戏了")
             return
 
-        spec = self.level_preset.get(level, self.default_preset)
-        if level and level not in self.level_preset:
-            yield event.plain_result(f"难度仅支持：{list(self.level_preset.keys())}")
+        if self.cfg.is_supported_level(level_name):
+            yield event.plain_result(f"难度仅支持：{self.cfg.level_keys}")
             return
+        spec = self.cfg.get_spec(level_name)
 
         skin_name = (
             self.skin_mgr.get_skin_by_index(skin_index - 1)
             if skin_index
-            else self.config["default_skin"]
+            else self.cfg.default_skin
         )
         skin = self.skin_mgr.load(skin_name, spec)
 
         renderer = MineSweeperRenderer(
             spec=spec,
             skin=skin,
-            font_path=str(self.font_path),
+            font_path=str(self.cfg.font_path),
         )
 
         game = MineSweeper(spec, renderer)
@@ -120,13 +91,15 @@ class MinesweeperPlugin(Star):
             img_bytes = game.draw()
             img_path = self._save_img_bytes(event, img_bytes)
             asyncio.run_coroutine_threadsafe(
-                self.sender.send_img_replace_last(event, img_path), self.loop # type: ignore
+                self.sender.send_img_replace_last(event, img_path),
+                self.loop,  # type: ignore
             )
 
         game.on_send_board(send_board)
 
-        if self.config["use_gui"] and detect_desktop():
+        if self.cfg.use_gui and detect_desktop():
             from .core.gui import start_gui
+
             threading.Thread(
                 target=start_gui,
                 args=(game,),
@@ -199,9 +172,9 @@ class MinesweeperPlugin(Star):
         if (
             game.is_fail
             and isinstance(event, AiocqhttpMessageEvent)
-            and self.config["ban_time"] > 0
+            and self.cfg.ban_time > 0
         ):
-            await set_group_ban(event, ban_time=self.config["ban_time"])
+            await set_group_ban(event, ban_time=self.cfg.ban_time)
 
     @filter.regex(r"^标雷(\s*[a-zA-Z][0-9]+)+$")
     async def mark_minesweeper(self, event: AstrMessageEvent):


### PR DESCRIPTION
## Summary by Sourcery

为扫雷（Minesweeper）插件引入强类型的插件配置，并集中管理相关路径和难度预设。

新特性：
- 新增 `PluginConfig` 类，为插件设置、难度预设和文件系统路径提供强类型访问。

漏洞修复：
- 当未配置任何难度等级时，通过填充回退预设及其映射，确保有可用的默认难度等级。

改进：
- 重构 `MinesweeperPlugin`，使用新的 `PluginConfig` 处理配置、缓存管理、资源路径以及难度选择。
- 更新 `SkinManager`，使其通过共享的插件配置进行初始化，而不是直接使用皮肤目录路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a strongly typed plugin configuration for the Minesweeper plugin and centralize related paths and difficulty presets.

New Features:
- Add a PluginConfig class to provide strongly typed access to plugin settings, difficulty presets, and filesystem paths.

Bug Fixes:
- Ensure a default difficulty level is available when none is configured by populating a fallback preset and mapping.

Enhancements:
- Refactor MinesweeperPlugin to use the new PluginConfig for configuration, cache handling, resource paths, and difficulty selection.
- Update SkinManager to be initialized with the shared plugin configuration instead of a raw skins directory path.

</details>