### PR TITLE
bugfix:qqbot与astrbot不在同一个机器上，发送图片会失败

### DIFF
--- a/core/image_service.py
+++ b/core/image_service.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import base64
 
 from astrbot.api.event import AstrMessageEvent
 from astrbot.core.config.astrbot_config import AstrBotConfig
@@ -65,8 +66,13 @@ class ImageService:
         await self._recall_last_message(event)
 
         # 再发送新图片
+        image_file = Path(image_path)
+        image_bytes = image_file.read_bytes()
+        image_b64_bytes = base64.b64encode(image_bytes)
+        image_b64_str = str(image_b64_bytes, "utf-8")
         payloads = {
-            "message": [{"type": "image", "data": {"file": f"file://{image_path}"}}]
+            # "message": [{"type": "image", "data": {"file": f"file://{image_path}"}}]
+            "message": [{"type": "image", "data": {"file": f"base64://{image_b64_str}"}}]
         }
         message_id = await self._send_msg(event, payloads)
         if message_id:


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 通过避免使用本地文件路径引用，修复当 QQ 机器人和 Astrbot 运行在不同机器上时出现的图片发送失败问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix image sending failures when QQ bot and Astrbot run on different machines by avoiding local file path references.

</details>