### PR TITLE
New

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## v1.3.1
+
+New Features:
+- 添加 `MessageSender` 工具类，将棋盘图片保存到缓存中，并在包括 QQ 官方机器人和 OneBot 在内的受支持平台上发送这些图片。
+- 支持在平台允许的情况下，按会话和发送者维度，通过回溯上一条消息来替换最近一次发送的棋盘图片。
+
+Enhancements:
+- 重构 `CommandHandler` 和主初始化流程，使其在棋盘渲染与投递上依赖 `MessageSender` 而非 `ImageService`。
+- 在 `CommandHandler` 中通过基于事件来源的统一游戏键，规范游戏查找逻辑。
+- 在新的核心 sender 到位后，移除旧的顶层 sender 模块。
+
 ## v1.3.0
 
 New Features:

--- a/core/command_handler.py
+++ b/core/command_handler.py
@@ -144,15 +144,17 @@ class CommandHandler:
 
     def stop_game(self, event: AstrMessageEvent):
         uid = event.get_sender_id()
-        if not self.game_service.is_running(event.session_id):
+        umo = event.unified_msg_origin
+        if not self.game_service.is_running(umo):
             logger.debug(f"[扫雷] 用户 {uid} 尝试结束不存在的游戏")
             return "当前没有进行中的扫雷游戏"
-        self.game_service.stop(event.session_id)
+        self.game_service.stop(umo)
         logger.info(f"[扫雷] 用户 {uid} 结束游戏")
         return "已结束扫雷游戏"
 
     async def show_board(self, event: AstrMessageEvent):
-        game = self.game_service.get(event.session_id)
+        umo = event.unified_msg_origin
+        game = self.game_service.get(umo)
         if not game:
             logger.debug(f"[扫雷] 用户 {event.get_sender_id()} 查看不存在的棋盘")
             return None
@@ -163,7 +165,8 @@ class CommandHandler:
         self, event: AstrMessageEvent, game: MineSweeper | None = None
     ) -> bool:
         if game is None:
-            game = self.game_service.get(event.session_id)
+            umo = event.unified_msg_origin
+            game = self.game_service.get(umo)
         if not game:
             return False
         img_path = self.image_service.save_cache(event, game.draw())
@@ -178,7 +181,8 @@ class CommandHandler:
         *,
         defer_output: bool = False,
     ) -> tuple[bool, MineSweeper | None, list[str]]:
-        game = self.game_service.get(event.session_id)
+        umo = event.unified_msg_origin
+        game = self.game_service.get(umo)
         if not game:
             return False, None, []
 
@@ -196,7 +200,7 @@ class CommandHandler:
             for pos in _expand_position_token(token) or []:
                 x = ord(pos[0]) - ord("a")
                 y = int(pos[1:]) - 1
-                result = self.game_service.apply(event.session_id, action, x, y)
+                result = self.game_service.apply(umo, action, x, y)
                 message = None
 
                 match result:

--- a/core/command_handler.py
+++ b/core/command_handler.py
@@ -10,8 +10,8 @@ from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
 from .config import PluginConfig
 from .game import MineSweeper
 from .game_service import GameService
-from .image_service import ImageService
 from .model import MarkResult, OpenResult, SweepResult
+from .sender import MessageSender
 
 _POSITION_PATTERN = re.compile(
     r"[a-zA-Z]\d+-[a-zA-Z]\d+|[a-zA-Z](?:-[a-zA-Z])?\d+(?:-\d+)?|[a-zA-Z]-[a-zA-Z]\d+"
@@ -80,12 +80,16 @@ class CommandHandler:
     def __init__(
         self,
         cfg: PluginConfig,
-        image_service: ImageService,
+        sender: MessageSender,
         game_service: GameService,
     ):
         self.cfg = cfg
         self.game_service = game_service
-        self.image_service = image_service
+        self.sender = sender
+
+    @staticmethod
+    def _game_key(event: AstrMessageEvent) -> str:
+        return event.unified_msg_origin
 
     async def start_game(
         self,
@@ -93,7 +97,7 @@ class CommandHandler:
         difficulty: str,
         skin_index: int | None,
     ):
-        umo = event.unified_msg_origin
+        umo = self._game_key(event)
         uid = event.get_sender_id()
         show_level = not difficulty
         difficulty = difficulty or self.cfg.default_difficulty
@@ -144,7 +148,7 @@ class CommandHandler:
 
     def stop_game(self, event: AstrMessageEvent):
         uid = event.get_sender_id()
-        umo = event.unified_msg_origin
+        umo = self._game_key(event)
         if not self.game_service.is_running(umo):
             logger.debug(f"[扫雷] 用户 {uid} 尝试结束不存在的游戏")
             return "当前没有进行中的扫雷游戏"
@@ -153,8 +157,7 @@ class CommandHandler:
         return "已结束扫雷游戏"
 
     async def show_board(self, event: AstrMessageEvent):
-        umo = event.unified_msg_origin
-        game = self.game_service.get(umo)
+        game = self.game_service.get(self._game_key(event))
         if not game:
             logger.debug(f"[扫雷] 用户 {event.get_sender_id()} 查看不存在的棋盘")
             return None
@@ -165,12 +168,11 @@ class CommandHandler:
         self, event: AstrMessageEvent, game: MineSweeper | None = None
     ) -> bool:
         if game is None:
-            umo = event.unified_msg_origin
-            game = self.game_service.get(umo)
+            game = self.game_service.get(self._game_key(event))
         if not game:
             return False
-        img_path = self.image_service.save_cache(event, game.draw())
-        await self.image_service.send_with_replace(event, img_path)
+        img_path = self.sender.save_cache(event, game.draw())
+        await self.sender.send_img_replace_last(event, img_path)
         return True
 
     async def _handle_positions(
@@ -181,8 +183,7 @@ class CommandHandler:
         *,
         defer_output: bool = False,
     ) -> tuple[bool, MineSweeper | None, list[str]]:
-        umo = event.unified_msg_origin
-        game = self.game_service.get(umo)
+        game = self.game_service.get(self._game_key(event))
         if not game:
             return False, None, []
 
@@ -200,7 +201,7 @@ class CommandHandler:
             for pos in _expand_position_token(token) or []:
                 x = ord(pos[0]) - ord("a")
                 y = int(pos[1:]) - 1
-                result = self.game_service.apply(umo, action, x, y)
+                result = self.game_service.apply(self._game_key(event), action, x, y)
                 message = None
 
                 match result:

--- a/core/sender.py
+++ b/core/sender.py
@@ -9,8 +9,8 @@ from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
 class MessageSender:
     """
     会话 + 用户级“覆盖发送”工具：
-    - 同一 session + 同一用户 只保留最后一条消息
-    - 新消息发送前自动撤回上一条
+    - 同一会话 + 同一用户 只保留最后一条消息
+    - 新消息发送时自动撤回上一条
     """
 
     def __init__(self, config: AstrBotConfig):
@@ -21,9 +21,9 @@ class MessageSender:
     @staticmethod
     def _make_key(event: AiocqhttpMessageEvent) -> str:
         """
-        session + sender 作为唯一键
+        umo + sender 作为唯一键
         """
-        return f"{event.session_id}:{event.get_sender_id()}"
+        return f"{event.unified_msg_origin}:{event.get_sender_id()}"
 
     @staticmethod
     async def _send_msg(event: AiocqhttpMessageEvent, payloads: dict) -> int | None:

--- a/core/sender.py
+++ b/core/sender.py
@@ -1,35 +1,32 @@
-from astrbot.api.event import AstrMessageEvent
+from pathlib import Path
+
+import botpy.message
+from botpy.http import Route
+
+from astrbot.api.event import AstrMessageEvent, MessageChain
 from astrbot.core.config.astrbot_config import AstrBotConfig
 from astrbot.core.message.components import Image
 from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
     AiocqhttpMessageEvent,
 )
+from astrbot.core.platform.sources.qqofficial.qqofficial_message_event import (
+    QQOfficialMessageEvent,
+)
 
 
 class MessageSender:
-    """
-    会话 + 用户级“覆盖发送”工具：
-    - 同一会话 + 同一用户 只保留最后一条消息
-    - 新消息发送时自动撤回上一条
-    """
-
-    def __init__(self, config: AstrBotConfig):
+    def __init__(self, cache_dir: Path, config: AstrBotConfig | None = None):
+        self.cache_dir = cache_dir
         self.config = config
-        # key(session_id:uid) -> last message_id
-        self._last_message_id: dict[str, int] = {}
+        self._last_message_id: dict[str, str | int] = {}
 
     @staticmethod
-    def _make_key(event: AiocqhttpMessageEvent) -> str:
-        """
-        umo + sender 作为唯一键
-        """
+    def _make_key(event: AstrMessageEvent) -> str:
         return f"{event.unified_msg_origin}:{event.get_sender_id()}"
 
     @staticmethod
     async def _send_msg(event: AiocqhttpMessageEvent, payloads: dict) -> int | None:
-        """
-        发送消息并返回 message_id
-        """
+        """Send a message through OneBot and return its message ID."""
         if event.is_private_chat():
             payloads["user_id"] = event.get_sender_id()
             result = await event.bot.api.call_action("send_private_msg", **payloads)
@@ -39,37 +36,86 @@ class MessageSender:
 
         return result.get("message_id")
 
-    async def _recall_last_message(self, event: AiocqhttpMessageEvent):
-        """
-        撤回当前 session + 用户 上一次发送的消息（若存在）
-        """
+    def save_cache(self, event: AstrMessageEvent, img_bytes: bytes) -> str:
+        """save cache"""
+        key = self._make_key(event).replace(":", "_")
+        image_path = self.cache_dir / f"{key}.png"
+        image_path.write_bytes(img_bytes)
+        return str(image_path.absolute())
+
+    async def _recall_qqofficial_message(
+        self, event: QQOfficialMessageEvent, message_id: str
+    ) -> None:
+        """Recall a message through the QQ Official API"""
+        source = event.message_obj.raw_message
+        route_path = None
+        route_params = {}
+
+        if isinstance(source, botpy.message.GroupMessage):
+            route_path = "/v2/groups/{group_openid}/messages/{message_id}"
+            route_params["group_openid"] = source.group_openid
+        elif isinstance(source, botpy.message.C2CMessage):
+            route_path = "/v2/users/{openid}/messages/{message_id}"
+            route_params["openid"] = source.author.user_openid
+        elif isinstance(source, botpy.message.DirectMessage):
+            route_path = "/dms/{guild_id}/messages/{message_id}"
+            route_params["guild_id"] = source.guild_id
+        elif isinstance(source, botpy.message.Message):
+            await event.bot.api.recall_message(
+                channel_id=source.channel_id,
+                message_id=message_id,
+            )
+            return
+
+        if route_path:
+            await event.bot.api._http.request(
+                Route(
+                    "DELETE",
+                    route_path,
+                    message_id=message_id,
+                    **route_params,
+                )
+            )
+
+    async def _recall_last_message(self, event: AstrMessageEvent):
+        """Recall the last image sent for this session and sender when supported."""
         key = self._make_key(event)
         last_message_id = self._last_message_id.get(key)
-
         if not last_message_id:
             return
 
         try:
-            await event.bot.delete_msg(message_id=last_message_id)
+            if isinstance(event, AiocqhttpMessageEvent):
+                await event.bot.delete_msg(message_id=int(last_message_id))
+            elif isinstance(event, QQOfficialMessageEvent):
+                await self._recall_qqofficial_message(event, str(last_message_id))
         except Exception:
-            # 已被撤回 / 超时 / 权限不足等情况，直接忽略
             pass
         finally:
             self._last_message_id.pop(key, None)
 
     async def send_img_replace_last(self, event: AstrMessageEvent, image_path: str):
-        """
-        发送图片，并撤回同 session + 同用户 上一次发送的消息
-        """
-        if not isinstance(event, AiocqhttpMessageEvent):
-            await event.send(event.chain_result([Image.fromFileSystem(image_path)]))
+        """Send an image and replace the previous image for this session and sender."""
+        key = self._make_key(event)
+        message_id: str | int | None = None
+
+        if isinstance(event, AiocqhttpMessageEvent):
+            payloads = {"message": [{"type": "image", "data": {"file": image_path}}]}
+            message_id = await self._send_msg(event, payloads)
+        elif isinstance(event, QQOfficialMessageEvent):
+            platform = getattr(event.bot, "platform", None)
+            if platform is None:
+                return
+            message_chain = MessageChain([Image.fromFileSystem(image_path)])
+            await platform.send_by_session(event.session, message_chain)
+            message_id = getattr(platform, "_session_last_message_id", {}).get(
+                event.session_id
+            )
+        else:
+            message_chain = MessageChain([Image.fromFileSystem(image_path)])
+            await event.send(message_chain)
             return
-        payloads = {"message": [{"type": "image", "data": {"file": image_path}}]}
-        message_id = await self._send_msg(event, payloads)
 
         await self._recall_last_message(event)
-
-        # 3. 记录 message_id
         if message_id:
-            key = self._make_key(event)
             self._last_message_id[key] = message_id

--- a/core/sender.py
+++ b/core/sender.py
@@ -4,7 +4,6 @@ import botpy.message
 from botpy.http import Route
 
 from astrbot.api.event import AstrMessageEvent, MessageChain
-from astrbot.core.config.astrbot_config import AstrBotConfig
 from astrbot.core.message.components import Image
 from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
     AiocqhttpMessageEvent,
@@ -15,9 +14,8 @@ from astrbot.core.platform.sources.qqofficial.qqofficial_message_event import (
 
 
 class MessageSender:
-    def __init__(self, cache_dir: Path, config: AstrBotConfig | None = None):
+    def __init__(self, cache_dir: Path):
         self.cache_dir = cache_dir
-        self.config = config
         self._last_message_id: dict[str, str | int] = {}
 
     @staticmethod

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from .core.command_handler import CommandHandler
 from .core.config import PluginConfig
 from .core.game_service import GameService
-from .core.image_service import ImageService
+from .core.sender import MessageSender
 from .core.skin import SkinManager
 from .core.web_controller import WebController
 
@@ -20,7 +20,7 @@ class MinesweeperPlugin(Star):
         self.cfg = PluginConfig(config, context)
 
         self.skin_mgr = SkinManager(self.cfg)
-        self.image_service = ImageService(self.cfg.cache_dir)
+        self.sender = MessageSender(self.cfg.cache_dir)
         self.game_service = GameService(self.cfg, self.skin_mgr)
         self.web_controller = WebController(
             context=context,
@@ -30,7 +30,7 @@ class MinesweeperPlugin(Star):
         self.cmd_handler = CommandHandler(
             cfg=self.cfg,
             game_service=self.game_service,
-            image_service=self.image_service,
+            sender=self.sender,
         )
 
     async def initialize(self):

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,7 +2,7 @@ name: astrbot_plugin_minesweeper
 display_name: 扫雷游戏
 desc: 经典的扫雷小游戏
 help: 略
-version: v1.3.0
+version: v1.3.1
 author: Zhalslar
 repo: https://github.com/Zhalslar/astrbot_plugin_minesweeper
 astrbot_version: ">=4.26.1"


### PR DESCRIPTION
## Summary by Sourcery

为扫雷引入一套消息发送抽象，用于跟踪每个会话的棋盘图片，并在平台支持的情况下回溯并替换此前发送的图片。

New Features:
- 添加 `MessageSender` 工具类，将棋盘图片保存到缓存中，并在包括 QQ 公众号和 OneBot 在内的受支持平台上发送这些图片。
- 支持在平台允许的情况下，按会话和发送者维度，通过回溯上一条消息来替换最近一次发送的棋盘图片。

Enhancements:
- 重构 `CommandHandler` 和主初始化流程，使其在棋盘渲染与投递上依赖 `MessageSender` 而非 `ImageService`。
- 在 `CommandHandler` 中通过基于事件来源的统一游戏键，规范游戏查找逻辑。
- 在新的核心 sender 到位后，移除旧的顶层 sender 模块。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a message sending abstraction for Minesweeper that tracks per-session images and recalls previous ones when supported.

New Features:
- Add a MessageSender utility that saves board images to cache and sends them across supported platforms, including QQ Official and OneBot.
- Support replacing the last sent board image per session and sender by recalling the previous message when the platform allows it.

Enhancements:
- Refactor CommandHandler and main initialization to depend on MessageSender instead of ImageService for board rendering and delivery.
- Standardize game lookup in CommandHandler via a unified game key based on the event origin.
- Remove the legacy top-level sender module now that the new core sender is in place.

</details>